### PR TITLE
feat(PatternFormat): add input validation support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,14 @@
         "vitest": "^4.0.15",
         "vitest-browser-svelte": "^2.0.1"
       },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/pitis"
+      },
       "peerDependencies": {
         "svelte": "^5.0.0"
       }
@@ -212,6 +220,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -255,6 +264,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1403,6 +1413,7 @@
       "integrity": "sha512-vByReCTTdlNM80vva8alAQC80HcOiHLkd8XAxIiKghKSHcqeNfyhp3VsYAV8VSiPKu4Jc8wWCfsZNAIvd1uCqA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "@sveltejs/acorn-typescript": "^1.0.5",
@@ -1495,6 +1506,7 @@
       "integrity": "sha512-YZs/OSKOQAQCnJvM/P+F1URotNnYNeU3P2s4oIpzm1uFaqUEqRxUB0g5ejMjEb5Gjb9/PiBI5Ktrq4rUUF8UVQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte-inspector": "^5.0.0",
         "debug": "^4.4.1",
@@ -1636,6 +1648,7 @@
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1686,6 +1699,7 @@
       "integrity": "sha512-PC0PDZfJg8sP7cmKe6L3QIL8GZwU5aRvUFedqSIpw3B+QjRSUZeeITC2M5XKeMXEzL6wccN196iy3JLwKNvDVA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.1",
         "@typescript-eslint/types": "8.48.1",
@@ -1926,6 +1940,7 @@
       "integrity": "sha512-94yVpDbb+ykiT7mK6ToonGnq2GIHEQGBTZTAzGxBGQXcVNCh54YKC2/WkfaDzxy0m6Kgw05kq3FYHKHu+wRdIA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/browser": "4.0.15",
         "@vitest/mocker": "4.0.15",
@@ -2061,6 +2076,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2664,6 +2680,7 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3444,6 +3461,7 @@
       "integrity": "sha512-454TI39PeRDW1LgpyLPyURtB4Zx1tklSr6+OFOipsxGUH1WMTvk6C65JQdrj455+DP2uJ1+veBEHTGFKWVLFoA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.23",
         "@asamuzakjp/dom-selector": "^6.7.4",
@@ -4028,6 +4046,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4136,6 +4155,7 @@
       "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright-core": "1.57.0"
       },
@@ -4192,6 +4212,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4325,6 +4346,7 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -4862,6 +4884,7 @@
       "integrity": "sha512-1/Y6ZfAQ30GjebMrDFM8ktL1WZ0ylljLabotDAFN41MTrDOY4gGzDDYnIKV+p8YXcnxEEDpVfVWE+I6u69jJ7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -5127,6 +5150,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5213,6 +5237,7 @@
       "integrity": "sha512-tI2l/nFHC5rLh7+5+o7QjKjSR04ivXDF4jcgV0f/bTQ+OJiITy5S6gaynVsEM+7RqzufMnVbIon6Sr5x1SDYaQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -5336,6 +5361,7 @@
       "integrity": "sha512-n1RxDp8UJm6N0IbJLQo+yzLZ2sQCDyl1o0LeugbPWf8+8Fttp29GghsQBjYJVmWq3gBFfe9Hs1spR44vovn2wA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.15",
         "@vitest/mocker": "4.0.15",

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,0 +1,19 @@
+export function validateBrazilianCPFDigit(
+  cpf: string,
+  position: number
+): boolean {
+  let sum = 0
+  let weight = position
+
+  // Iterate over the digits preceding the check digit
+  for (let i = 0; i < position - 1; i++) {
+    sum += parseInt(cpf[i]) * weight
+    weight--
+  }
+
+  const remainder = (sum * 10) % 11
+  const calculatedDigit = remainder === 10 || remainder === 11 ? 0 : remainder
+
+  // Compare calculated digit with the actual digit in the string
+  return calculatedDigit === parseInt(cpf[position - 1])
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -10,3 +10,9 @@ export { default as SvelteMaskFormat } from './PatternFormat.svelte'
 export { NumberFormatStyle } from 'intl-number-input'
 export { MaskPatterns } from './maskPatterns.js'
 export type { MaskPattern } from './maskPatterns.js'
+export { InputValidators } from './inputValidations.js'
+export type {
+  AllowedInputValidators,
+  InputValidator,
+  InputValidatorsKeys
+} from './inputValidations.js'

--- a/src/lib/inputValidations.ts
+++ b/src/lib/inputValidations.ts
@@ -1,0 +1,33 @@
+import { validateBrazilianCPFDigit } from './helpers.js'
+import type { MaskPatternKeys } from './maskPatterns.js'
+
+/**
+ * Functions:
+ * A validation function should take a string as argument
+ * and return a boolean indicating whether the input is valid.
+ *
+ * (value: string) => boolean
+ */
+export type InputValidator = (value: string) => boolean
+
+export type AllowedInputValidators = {
+  [k in MaskPatternKeys]: InputValidator
+}
+export const InputValidators: Partial<AllowedInputValidators> = {
+  BRAZILIAN_CPF: (value: string) => {
+    if (!value) return false
+
+    const cleanCPF = value.replace(/\D/g, '')
+
+    if (cleanCPF.length !== 11) return false
+
+    if (/^(\d)\1+$/.test(cleanCPF)) return false
+
+    if (!validateBrazilianCPFDigit(cleanCPF, 10)) return false // 1st Check Digit
+    if (!validateBrazilianCPFDigit(cleanCPF, 11)) return false // 2nd Check Digit
+
+    return true
+  }
+} as const
+
+export type InputValidatorsKeys = keyof typeof InputValidators

--- a/src/lib/maskPatterns.ts
+++ b/src/lib/maskPatterns.ts
@@ -28,6 +28,7 @@ export const MaskPatterns = {
 
   // Identification
   SSN: '###-##-####',
+  BRAZILIAN_CPF: '###.###.###-##',
   ZIP_US: '#####',
   ZIP_US_PLUS4: '#####-####',
 
@@ -37,6 +38,6 @@ export const MaskPatterns = {
   HEX_COLOR: '#******'
 } as const
 
-export type MaskPattern =
-  | (typeof MaskPatterns)[keyof typeof MaskPatterns]
-  | string
+export type MaskPatternKeys = keyof typeof MaskPatterns
+
+export type MaskPattern = (typeof MaskPatterns)[MaskPatternKeys] | string

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { InputValidators } from '$lib/inputValidations.js'
   import {
     NumericFormat,
     PatternFormat,
@@ -23,6 +24,59 @@
   let ssnInput = $state<string | null>(null)
   let zipCode = $state<string | null>(null)
   let customMask = $state<string | null>(null)
+
+  // CPF related states
+  type cpfValidationOptions =
+    | 'none'
+    | 'css-class'
+    | 'data-attribute'
+    | 'callback'
+  let cpfInput = $state<string | null>(null)
+  let previousCpfValidationOption: cpfValidationOptions = 'none'
+  let cpfValidationOption = $state<cpfValidationOptions>('none')
+  let validationConfig = $derived.by(() => {
+    let validate = InputValidators.BRAZILIAN_CPF
+    if (validate === undefined) {
+      console.warn(`No validator found for key: BRAZILIAN_CPF`)
+
+      validate = () => true
+    }
+
+    switch (cpfValidationOption) {
+      case 'css-class':
+        return {
+          reportAs: 'css-class',
+          validate,
+          className: {
+            valid: 'input-valid',
+            invalid: 'input-error'
+          },
+          applyOn: 'input'
+        } as const
+
+      case 'data-attribute':
+        return {
+          reportAs: 'data-attribute',
+          validate,
+          attributeName: 'data-is-valid',
+          applyOn: 'change'
+        } as const
+
+      case 'callback':
+        return {
+          reportAs: 'callback',
+          applyOn: 'both',
+          validate,
+          onValidation: (isValid: boolean) => {
+            console.log('CPF validation result:', isValid)
+          }
+        } as const
+
+      case 'none':
+      default:
+        return undefined
+    }
+  })
 
   // Dark mode state
   let darkMode = $state(false)
@@ -61,6 +115,19 @@
 
   function handleMaskInput(raw: string | null, masked: string | null) {
     console.log('Mask Input - Raw:', raw, 'Masked:', masked)
+  }
+
+  function handleBrazilianCPFValidationSelection() {
+    const inputEl = document.getElementById('cpf-input') as HTMLInputElement
+
+    if (previousCpfValidationOption === 'css-class') {
+      inputEl.classList.remove('input-valid')
+      inputEl.classList.remove('input-error')
+    } else if (previousCpfValidationOption === 'data-attribute') {
+      inputEl.removeAttribute('data-is-valid')
+    }
+
+    previousCpfValidationOption = cpfValidationOption
   }
 </script>
 
@@ -262,6 +329,75 @@
   </div>
 
   <div class="example">
+    <h2>Brazilian CPF</h2>
+    <PatternFormat
+      id="cpf-input"
+      bind:value={cpfInput}
+      format={MaskPatterns.BRAZILIAN_CPF}
+      placeholder="123.123.123-00"
+      class="input"
+      withValidation={validationConfig}
+    />
+    <p>Raw Value: {cpfInput || 'null'}</p>
+    <p>Pattern: ###.###.###-##</p>
+    <fieldset class="radio-group">
+      <legend>With value validation</legend>
+      <div>
+        <input
+          type="radio"
+          id="none"
+          name="validation-option"
+          value="none"
+          checked
+          bind:group={cpfValidationOption}
+          onchange={handleBrazilianCPFValidationSelection}
+        />
+        <label for="none">None</label>
+      </div>
+      <div>
+        <input
+          type="radio"
+          id="css-class"
+          name="validation-option"
+          value="css-class"
+          bind:group={cpfValidationOption}
+          onchange={handleBrazilianCPFValidationSelection}
+        />
+        <label for="css-class">
+          Class Name (input-error) - Text color style - Apply on input event</label
+        >
+      </div>
+      <div>
+        <input
+          type="radio"
+          id="data-attribute"
+          name="validation-option"
+          value="data-attribute"
+          bind:group={cpfValidationOption}
+          onchange={handleBrazilianCPFValidationSelection}
+        />
+        <label for="data-attribute">
+          Data Attribute (data-is-valid) - Border color style - Apply on change
+          event
+        </label>
+      </div>
+      <div>
+        <input
+          type="radio"
+          id="callback"
+          name="validation-option"
+          value="callback"
+          bind:group={cpfValidationOption}
+          onchange={handleBrazilianCPFValidationSelection}
+        />
+        <label for="callback">
+          Callback (console.log) - Printed to console - Apply on both events
+        </label>
+      </div>
+    </fieldset>
+  </div>
+
+  <div class="example">
     <h2>Custom Pattern</h2>
     <PatternFormat
       bind:value={customMask}
@@ -286,6 +422,8 @@
     --button-bg: #4a90e2;
     --button-bg-hover: #357abd;
     --button-text: #ffffff;
+    --success: #22bb33;
+    --destructive: #e55032;
     transition:
       background-color 0.3s ease,
       color 0.3s ease;
@@ -302,6 +440,8 @@
     --button-bg: #4a90e2;
     --button-bg-hover: #6db3f2;
     --button-text: #ffffff;
+    --success: #22bb33;
+    --destructive: #e55032;
   }
 
   :global(body) {
@@ -416,6 +556,28 @@
   :global(.input:focus) {
     outline: none;
     border-color: var(--border-color-focus);
+  }
+
+  :global(.input-valid) {
+    color: var(--success);
+    border-color: var(--success) !important;
+  }
+
+  :global(.input-error) {
+    color: var(--destructive);
+    border-color: var(--destructive) !important;
+  }
+
+  :global([data-is-valid='true']) {
+    border: 2px solid var(--success);
+    border-color: var(--success) !important;
+    background-color: color-mix(in srgb, var(--success), transparent 90%);
+  }
+
+  :global([data-is-valid='false']) {
+    border: 2px solid var(--destructive);
+    border-color: var(--destructive) !important;
+    background-color: color-mix(in srgb, var(--destructive), transparent 90%);
   }
 
   p {


### PR DESCRIPTION
Introduces a new `withValidation` prop to the `PatternFormat` component, allowing for real-time input validation.

- Supports validation execution on 'input', 'change', or both events.
- Allows reporting validation results via:
  - CSS classes (valid/invalid).
  - Data attributes.
  - Callback function.
- Adds `inputValidations.ts` registry for reusable validators.
- Implements `BRAZILIAN_CPF` validator with helper logic.
- Adds comprehensive tests for validation triggers and reporting.