### PR TITLE
fix(publish): bump to Node 24 instead of upgrading npm at runtime

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,14 +19,11 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          # Node 24 ships with npm 11.6+, which is above the 11.5.1 minimum
+          # for trusted publishing (OIDC). Node 22 still bundles npm 10.x.
+          node-version: 24
           registry-url: https://registry.npmjs.org
           cache: npm
-
-      # Trusted publishing (OIDC) requires npm >= 11.5.1.
-      # Node 22 still ships with npm 10.x, so upgrade explicitly.
-      - name: Upgrade npm
-        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
The previous attempt added a `npm install -g npm@latest` step on top of Node 22 to pick up trusted-publishing support. That step failed on the hosted runner (likely a self-upgrade permission issue).

Node 24.x ships with npm 11.6+ out of the box — well above the 11.5.1 minimum needed for trusted publishing — so just use it directly and drop the manual upgrade step. Simpler and removes a class of failures.